### PR TITLE
also catch rust error messages that have been caught and resumed

### DIFF
--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -183,8 +183,7 @@ OUT_OF_MEMORY_REGEX = re.compile(r'.*(?:%s).*' % '|'.join([
 ]))
 RUNTIME_ERROR_REGEX = re.compile(r'#\s*Runtime error in (.*)')
 RUNTIME_ERROR_LINE_REGEX = re.compile(r'#\s*Runtime error in (.*), line [0-9]+')
-RUST_ASSERT_REGEX = re.compile(r'thread\s.*\spanicked at \'([^\']*)',
-                               re.IGNORECASE)
+RUST_ASSERT_REGEX = re.compile(r'.*panicked at \'([^\']*)', re.IGNORECASE)
 SAN_ABRT_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: ABRT ')
 SAN_BREAKPOINT_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: breakpoint ')
 SAN_CHECK_FAILURE_REGEX = re.compile(


### PR DESCRIPTION
This, in particular, should make fuzzers built with [cargo-bolero](https://github.com/camshaft/bolero) able to get the proper error message auto-detected, rather than a generic abort.